### PR TITLE
Strictly return the response from the API without using .ToJson()

### DIFF
--- a/checkout-example/Controllers/ApiController.cs
+++ b/checkout-example/Controllers/ApiController.cs
@@ -29,7 +29,7 @@ namespace adyen_dotnet_checkout_example.Controllers
         }
 
         [HttpPost("api/sessions")]
-        public async Task<ActionResult<string>> Sessions(CancellationToken cancellationToken = default)
+        public async Task<ActionResult<CreateCheckoutSessionResponse>> Sessions(CancellationToken cancellationToken = default)
         {
             var orderRef = Guid.NewGuid();
             var sessionsRequest = new CreateCheckoutSessionRequest()
@@ -56,7 +56,7 @@ namespace adyen_dotnet_checkout_example.Controllers
             {
                 var res = await _paymentsService.SessionsAsync(sessionsRequest, cancellationToken: cancellationToken);
                 _logger.LogInformation($"Response for Payments API:\n{res}\n");
-                return res.ToJson();
+                return res;
             }
             catch (Adyen.HttpClient.HttpClientException e)
             {

--- a/giftcard-example/Controllers/ApiController.cs
+++ b/giftcard-example/Controllers/ApiController.cs
@@ -29,7 +29,7 @@ namespace adyen_dotnet_giftcard_example.Controllers
         }
 
         [HttpPost("api/sessions/dropin")]
-        public async Task<ActionResult<string>> SessionsDropin(CancellationToken cancellationToken = default)
+        public async Task<ActionResult<CreateCheckoutSessionResponse>> SessionsDropin(CancellationToken cancellationToken = default)
         {
             var orderRef = Guid.NewGuid();
             var sessionsRequest = new CreateCheckoutSessionRequest()
@@ -57,7 +57,7 @@ namespace adyen_dotnet_giftcard_example.Controllers
             {
                 var res = await _paymentsService.SessionsAsync(sessionsRequest, cancellationToken: cancellationToken);
                 _logger.LogInformation($"Response Payments API:\n{res}\n");
-                return res.ToJson();
+                return res;
             }
             catch (Adyen.HttpClient.HttpClientException e)
             {
@@ -67,7 +67,7 @@ namespace adyen_dotnet_giftcard_example.Controllers
         }
 
         [HttpPost("api/sessions/giftcardcomponent")]
-        public async Task<ActionResult<string>> SessionsGiftcardComponent(CancellationToken cancellationToken = default)
+        public async Task<ActionResult<CreateCheckoutSessionResponse>> SessionsGiftcardComponent(CancellationToken cancellationToken = default)
         {
             var orderRef = Guid.NewGuid();
             var sessionsRequest = new CreateCheckoutSessionRequest()
@@ -95,7 +95,7 @@ namespace adyen_dotnet_giftcard_example.Controllers
             {
                 var res = await _paymentsService.SessionsAsync(sessionsRequest, cancellationToken: cancellationToken);
                 _logger.LogInformation($"Response Payments API: \n{res}\n");
-                return res.ToJson();
+                return res;
             }
             catch (Adyen.HttpClient.HttpClientException e)
             {

--- a/paybylink-example/Controllers/ApiController.cs
+++ b/paybylink-example/Controllers/ApiController.cs
@@ -21,7 +21,7 @@ namespace adyen_dotnet_paybylink_example.Controllers
         }
 
         [HttpPost("api/links")]
-        public async Task<ActionResult<string>> CreatePaymentLink(Requests.CreatePaymentLinkRequest request, CancellationToken cancellationToken = default)
+        public async Task<ActionResult<PaymentLinkResponse>> CreatePaymentLink(Requests.CreatePaymentLinkRequest request, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/subscription-example/Clients/CheckoutClient.cs
+++ b/subscription-example/Clients/CheckoutClient.cs
@@ -1,5 +1,4 @@
 ﻿using Adyen.Model.Checkout;
-using Adyen.Service;
 using adyen_dotnet_subscription_example.Options;
 using adyen_dotnet_subscription_example.Services;
 using Microsoft.Extensions.Logging;

--- a/subscription-example/Controllers/TokenizationController.cs
+++ b/subscription-example/Controllers/TokenizationController.cs
@@ -1,4 +1,5 @@
 ﻿using adyen_dotnet_subscription_example.Clients;
+using Adyen.Model.Checkout;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,10 +20,10 @@ namespace adyen_dotnet_subscription_example.Controllers
         /// This method creates a token using the /sessions endpoint.
         /// </summary>
         [HttpPost("api/tokenization/sessions")]
-        public async Task<ActionResult<string>> Sessions(CancellationToken cancellationToken = default)
+        public async Task<ActionResult<CreateCheckoutSessionResponse>> Sessions(CancellationToken cancellationToken = default)
         {
             var result = await _checkoutService.CheckoutSessionsAsync(ShopperReference.Value, cancellationToken);
-            return result.ToJson();
+            return result;
         }
     }
 }


### PR DESCRIPTION
**Description** 
Removed `ActionResult<string>` from the `Controller`-level as returnable response to clarify what json is sent back from the backend. In an ideal world, a developer would preferably convert (aka. mapping) the AdyenResponse to their own ResponseDto .