### PR TITLE
Tokenization - Use "RECURRING_CONTRACT" eventCode in webhook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,13 @@ name: .NET
 
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/checkout-example-advanced/Properties/launchSettings.json
+++ b/checkout-example-advanced/Properties/launchSettings.json
@@ -16,17 +16,6 @@
       },
       "applicationUrl": "https://localhost:5001;http://localhost:8080"
     },
-    "adyen_dotnet_checkout_example_advanced_port_tunneling": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:5001;http://localhost:8080",
-      // The following two properties enable dev tunnels in visual studio 17.4+. This is used to proxy your localhost and receive webhooks.
-      "devTunnelEnabled": true,
-      "devTunnelAccess": "public"
-    },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,

--- a/checkout-example-advanced/Properties/launchSettings.json
+++ b/checkout-example-advanced/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "adyen_dotnet_checkout_example_advanced": {
+    "Checkout Example Advanced": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/checkout-example-advanced/readme.md
+++ b/checkout-example-advanced/readme.md
@@ -74,10 +74,8 @@ To expose this endpoint locally, we have highlighted two options in step 4 or 5.
 
 
 4. Expose your localhost with Visual Studio using dev tunnels.
-    - Add `https://*.devtunnels.ms` to your allowed origins
-    - Login to Visual Studio
-    - Under `Options` → `Environment` → `Preview Features` → Check `Enable dev tunnels for Web Application`
-    - Select `adyen_dotnet_checkout_example_port_tunneling` as your launch settings profile
+     - Add `https://*.devtunnels.ms` to your allowed origins
+     - Create your public (temporary/persistent) dev tunnel by following [this guide](https://learn.microsoft.com/en-us/aspnet/core/test/dev-tunnels?view=aspnetcore-7.0)
 
 If you use Visual Studio 17.4 or higher, the webhook URL will be the generated URL (i.e. `https://xd1r2txt-5001.euw.devtunnels.ms`).
 
@@ -134,7 +132,7 @@ set ADYEN_HMAC_KEY=yourAdyenHmacKey
 
 
 ```shell
-dotnet run --project checkout-example 
+dotnet run --project checkout-example-advanced
 ```
 
 10. Update your webhook in your Customer Area with the public url that is generated.

--- a/checkout-example/Properties/launchSettings.json
+++ b/checkout-example/Properties/launchSettings.json
@@ -16,17 +16,6 @@
       },
       "applicationUrl": "https://localhost:5001;http://localhost:8080"
     },
-    "adyen_dotnet_checkout_example_port_tunneling": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:5001;http://localhost:8080",
-      // The following two properties enable dev tunnels in visual studio 17.4+. This is used to proxy your localhost and receive webhooks.
-      "devTunnelEnabled": true,
-      "devTunnelAccess": "public"
-    },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,

--- a/checkout-example/Properties/launchSettings.json
+++ b/checkout-example/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "adyen_dotnet_checkout_example": {
+    "Checkout Example": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/checkout-example/readme.md
+++ b/checkout-example/readme.md
@@ -72,12 +72,9 @@ git clone https://github.com/adyen-examples/adyen-dotnet-online-payments.git
 This demo provides a simple webhook integration at `/api/webhooks/notifications`. For it to work, you need to provide a way for Adyen's servers to reach your running application and add a standard webhook in the Customer Area.
 To expose this endpoint locally, we have highlighted two options in step 4 or 5. Choose one or consider alternative tunneling software.
 
-
 4. Expose your localhost with Visual Studio using dev tunnels.
-    - Add `https://*.devtunnels.ms` to your allowed origins
-    - Login to Visual Studio
-    - Under `Options` → `Environment` → `Preview Features` → Check `Enable dev tunnels for Web Application`
-    - Select `adyen_dotnet_checkout_example_port_tunneling` as your launch settings profile
+     - Add `https://*.devtunnels.ms` to your allowed origins
+     - Create your public (temporary/persistent) dev tunnel by following [this guide](https://learn.microsoft.com/en-us/aspnet/core/test/dev-tunnels?view=aspnetcore-7.0)
 
 If you use Visual Studio 17.4 or higher, the webhook URL will be the generated URL (i.e. `https://xd1r2txt-5001.euw.devtunnels.ms`).
 

--- a/giftcard-example/Properties/launchSettings.json
+++ b/giftcard-example/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "adyen_dotnet_giftcard_example": {
+    "Gift Card Example": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/giftcard-example/Properties/launchSettings.json
+++ b/giftcard-example/Properties/launchSettings.json
@@ -16,17 +16,6 @@
       },
       "applicationUrl": "https://localhost:5001;http://localhost:8080"
     },
-    "adyen_dotnet_giftcard_example_port_tunneling": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:5001;http://localhost:8080", 
-      // The following two properties enable dev tunnels in visual studio 17.4+. This is used to proxy your localhost and receive webhooks.
-      "devTunnelEnabled": true,
-      "devTunnelAccess": "public"
-    },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,

--- a/giftcard-example/readme.md
+++ b/giftcard-example/readme.md
@@ -69,12 +69,9 @@ git clone https://github.com/adyen-examples/adyen-dotnet-online-payments.git
 This demo provides a simple webhook integration at `/api/webhooks/notifications`. For it to work, you need to provide a way for Adyen's servers to reach your running application and add a standard webhook in the Customer Area.
 To expose this endpoint locally, we have highlighted two options in step 4 or 5. Choose one or consider alternative tunneling software.
 
-
 4. Expose your localhost with Visual Studio using dev tunnels.
-    - Add `https://*.devtunnels.ms` to your allowed origins
-    - Login to Visual Studio
-    - Under `Options` → `Environment` → `Preview Features` → Check `Enable dev tunnels for Web Application`
-    - Select `adyen_dotnet_giftcard_example_port_tunneling` as your launch settings profile
+     - Add `https://*.devtunnels.ms` to your allowed origins
+     - Create your public (temporary/persistent) dev tunnel by following [this guide](https://learn.microsoft.com/en-us/aspnet/core/test/dev-tunnels?view=aspnetcore-7.0)
 
 If you use Visual Studio 17.4 or higher, the webhook URL will be the generated URL (i.e. `https://xd1r2txt-5001.euw.devtunnels.ms`).
 

--- a/paybylink-example/Properties/launchSettings.json
+++ b/paybylink-example/Properties/launchSettings.json
@@ -16,17 +16,6 @@
       },
       "applicationUrl": "https://localhost:5001;http://localhost:8080"
     },
-    "adyen_dotnet_paybylink_example_port_tunneling": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:5001;http://localhost:8080",
-      // The following two properties enable dev tunnels in visual studio 17.4+. This is used to proxy your localhost and receive webhooks.
-      "devTunnelEnabled": true,
-      "devTunnelAccess": "public"
-    },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,

--- a/paybylink-example/Properties/launchSettings.json
+++ b/paybylink-example/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "adyen_dotnet_paybylink_example": {
+    "Pay By Link Example": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/paybylink-example/readme.md
+++ b/paybylink-example/readme.md
@@ -66,10 +66,8 @@ To expose this endpoint locally, we have highlighted two options in step 4 or 5.
 
 
 4. Expose your localhost with Visual Studio using dev tunnels.
-    - Add `https://*.devtunnels.ms` to your allowed origins
-    - Login to Visual Studio
-    - Under `Options` → `Environment` → `Preview Features` → Check `Enable dev tunnels for Web Application`
-    - Select `adyen_dotnet_paybylink_example_port_tunneling` as your launch settings profile
+     - Add `https://*.devtunnels.ms` to your allowed origins
+     - Create your public (temporary/persistent) dev tunnel by following [this guide](https://learn.microsoft.com/en-us/aspnet/core/test/dev-tunnels?view=aspnetcore-7.0)
 
 If you use Visual Studio 17.4 or higher, the webhook URL will be the generated URL (i.e. `https://xd1r2txt-5001.euw.devtunnels.ms`).
 

--- a/subscription-example/Clients/CheckoutClient.cs
+++ b/subscription-example/Clients/CheckoutClient.cs
@@ -34,9 +34,9 @@ namespace adyen_dotnet_subscription_example.Clients
     public class CheckoutClient : ICheckoutClient
     {
         private readonly ILogger<RecurringClient> _logger;
-        private readonly string _merchantAccount;
         private readonly IPaymentsService _paymentsService;
         private readonly IUrlService _urlService;
+        private readonly string _merchantAccount;
 
         public CheckoutClient(ILogger<RecurringClient> logger, IPaymentsService paymentsService, IUrlService urlService, IOptions<AdyenOptions> options)
         {

--- a/subscription-example/Controllers/AdminController.cs
+++ b/subscription-example/Controllers/AdminController.cs
@@ -1,12 +1,11 @@
 ﻿using Adyen.HttpClient;
 using Adyen.Model.Checkout;
 using Adyen.Model.Recurring;
-using adyen_dotnet_subscription_example.Clients;
 using adyen_dotnet_subscription_example.Models;
 using adyen_dotnet_subscription_example.Repositories;
+using adyen_dotnet_subscription_example.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,14 +14,14 @@ namespace adyen_dotnet_subscription_example.Controllers
 {
     public class AdminController : Controller
     {
-        private readonly IRecurringClient _recurringClient;
-        private readonly ICheckoutClient _checkoutClient;
+        private readonly ISubscriptionService _subscriptionService;
+        private readonly ICheckoutService _checkoutClient;
         private readonly ISubscriptionRepository _repository;
         private readonly ILogger<AdminController> _logger;
 
-        public AdminController(IRecurringClient recurringClient, ICheckoutClient checkoutClient, ISubscriptionRepository repository, ILogger<AdminController> logger)
+        public AdminController(ISubscriptionService subscriptionService, ICheckoutService checkoutClient, ISubscriptionRepository repository, ILogger<AdminController> logger)
         {
-            _recurringClient = recurringClient;
+            _subscriptionService = subscriptionService;
             _checkoutClient = checkoutClient;
             _repository = repository;
             _logger = logger;
@@ -76,7 +75,7 @@ namespace adyen_dotnet_subscription_example.Controllers
         {
             try
             {
-                DisableResult result = await _recurringClient.DisableRecurringDetailAsync(ShopperReference.Value, recurringDetailReference, cancellationToken);
+                DisableResult result = await _subscriptionService.DisableRecurringDetailAsync(ShopperReference.Value, recurringDetailReference, cancellationToken);
                 
                 switch (result.Response)
                 {

--- a/subscription-example/Controllers/AdminController.cs
+++ b/subscription-example/Controllers/AdminController.cs
@@ -5,6 +5,8 @@ using adyen_dotnet_subscription_example.Clients;
 using adyen_dotnet_subscription_example.Models;
 using adyen_dotnet_subscription_example.Repositories;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,12 +18,14 @@ namespace adyen_dotnet_subscription_example.Controllers
         private readonly IRecurringClient _recurringClient;
         private readonly ICheckoutClient _checkoutClient;
         private readonly ISubscriptionRepository _repository;
+        private readonly ILogger<AdminController> _logger;
 
-        public AdminController(IRecurringClient recurringClient, ICheckoutClient checkoutClient, ISubscriptionRepository repository)
+        public AdminController(IRecurringClient recurringClient, ICheckoutClient checkoutClient, ISubscriptionRepository repository, ILogger<AdminController> logger)
         {
             _recurringClient = recurringClient;
             _checkoutClient = checkoutClient;
             _repository = repository;
+            _logger = logger;
         }
 
         [Route("admin")]
@@ -58,10 +62,11 @@ namespace adyen_dotnet_subscription_example.Controllers
                         break;
                 }
             }   
-            catch (HttpClientException)
+            catch (HttpClientException e)
             {
                 ViewBag.Message = $"Payment failed for RecurringDetailReference {recurringDetailReference}. See error logs for the exception.";
                 ViewBag.Img = "failed";
+                _logger.LogError($"Payment failed for RecurringDetailReference {recurringDetailReference}: \n{e.ResponseBody}\n");
             }
             return View();
         }
@@ -85,10 +90,11 @@ namespace adyen_dotnet_subscription_example.Controllers
                         break;
                 }
             }
-            catch (HttpClientException)
+            catch (HttpClientException e)
             {
                 ViewBag.Message = $"Disable failed for RecurringDetailReference {recurringDetailReference}. See error logs for the exception.";
                 ViewBag.Img = "failed";
+                _logger.LogError($"Disable failed for RecurringDetailReference {recurringDetailReference}: \n{e.ResponseBody}\n");
             }
             return View();
         }

--- a/subscription-example/Controllers/TokenizationController.cs
+++ b/subscription-example/Controllers/TokenizationController.cs
@@ -1,17 +1,17 @@
-﻿using adyen_dotnet_subscription_example.Clients;
-using Adyen.Model.Checkout;
+﻿using Adyen.Model.Checkout;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading;
 using System.Threading.Tasks;
+using adyen_dotnet_subscription_example.Services;
 
 namespace adyen_dotnet_subscription_example.Controllers
 {
     [ApiController]
     public class TokenizationController : ControllerBase
     {
-        private readonly ICheckoutClient _checkoutService;
+        private readonly ICheckoutService _checkoutService;
 
-        public TokenizationController(ICheckoutClient checkoutService)
+        public TokenizationController(ICheckoutService checkoutService)
         {
             _checkoutService = checkoutService;
         }

--- a/subscription-example/Controllers/WebhookController.cs
+++ b/subscription-example/Controllers/WebhookController.cs
@@ -95,7 +95,7 @@ namespace adyen_dotnet_subscription_example.Controllers
 
         private Task ProcessRecurringContractNotificationAsync(NotificationRequestItem notification)
         {
-            // Read more about "RECURRING_CONTRACT" here: https://docs.adyen.com/online-payments/tokenization/create-and-use-tokens?tab=subscriptions_2#pending-and-refusal-result-codes-1.
+            // Read more about EventCode "RECURRING_CONTRACT" here: https://docs.adyen.com/online-payments/tokenization/create-and-use-tokens?tab=subscriptions_2#pending-and-refusal-result-codes-1.
             if (notification.EventCode != "RECURRING_CONTRACT")
             {
                 return Task.CompletedTask;

--- a/subscription-example/Controllers/WebhookController.cs
+++ b/subscription-example/Controllers/WebhookController.cs
@@ -65,12 +65,14 @@ namespace adyen_dotnet_subscription_example.Controllers
 
         private Task ProcessNotificationAsync(NotificationRequestItem notification)
         {
-            // (1) For the synchronous flow (enabled by default), check the "Authorisation" eventCode: 
-            // Read more: https://docs.adyen.com/online-payments/tokenization/create-and-use-tokens?tab=subscriptions_2#authorised-result-code-1
-
-            // (2) For the asynchronous flow, (enabled by contacting our support team), you need to check the "RECURRING_CONTRACT" eventCode instead of the "AUTHORISATION" eventCode.
-            // Read more: https://docs.adyen.com/online-payments/tokenization/create-and-use-tokens?tab=subscriptions_2#pending-and-refusal-result-codes-1
-            if (notification.EventCode != "AUTHORISATION")
+            // Per default, Adyen will send a webhook with the eventCode: "AUTHORISATION".
+            // We recommend changing this behavior in the Customer Area to receive the "RECURRING_CONTRACT" eventCode. 
+            // You'll need to do two things:
+            // (1) Enable the "RECURRING_CONTRACT" eventCode in your Customer Area, under "Developers" -> "Webhooks" -> "Settings". Enable "Recurring contract" on `Merchant`-level and hit "Save".
+            // This will send the event code "RECURRING_CONTRACT" when a recurring contract has been created.
+            // (2) Make sure that your webhook also sends the event "RECURRING_CONTRACT" ("Developers" -> "Webhooks" -> Click on your webhook -> "General").
+            // Read more here: https://docs.adyen.com/online-payments/tokenization/create-and-use-tokens?tab=subscriptions_2#pending-and-refusal-result-codes-1.
+            if (notification.EventCode != "RECURRING_CONTRACT")
             {
                 return Task.CompletedTask;
             }
@@ -103,7 +105,7 @@ namespace adyen_dotnet_subscription_example.Controllers
             // Get and log the recurringProcessingModel below.
             notification.AdditionalData.TryGetValue("recurringProcessingModel", out string recurringProcessingModel);
 
-            _logger.LogInformation($"Received recurringDetailReference: {recurringDetailReference} for {shopperReference}" +
+            _logger.LogInformation($"EventCode: {notification.EventCode} \nReceived recurringDetailReference: {recurringDetailReference} for {shopperReference} \n" +
                 $"RecurringProcessingModel: {recurringProcessingModel}");
 
             // Save the paymentMethod, shopperReference and recurringDetailReference in our in-memory cache.

--- a/subscription-example/Properties/launchSettings.json
+++ b/subscription-example/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "adyen_dotnet_subscription_example": {
+    "Subscription Example": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/subscription-example/Properties/launchSettings.json
+++ b/subscription-example/Properties/launchSettings.json
@@ -16,17 +16,6 @@
       },
       "applicationUrl": "https://localhost:5001;http://localhost:8080"
     },
-    "adyen_dotnet_subscription_example_port_tunnel": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:5001;http://localhost:8080",
-      // The following two properties enable dev tunnels in visual studio 17.4+. This is used to proxy your localhost and receive webhooks.
-      "devTunnelEnabled": true,
-      "devTunnelAccess": "public"
-    },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,

--- a/subscription-example/Services/CheckoutService.cs
+++ b/subscription-example/Services/CheckoutService.cs
@@ -1,16 +1,15 @@
 ﻿using Adyen.Model.Checkout;
+using Adyen.Service.Checkout;
 using adyen_dotnet_subscription_example.Options;
-using adyen_dotnet_subscription_example.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Adyen.Service.Checkout;
 
-namespace adyen_dotnet_subscription_example.Clients
+namespace adyen_dotnet_subscription_example.Services
 {
-    public interface ICheckoutClient
+    public interface ICheckoutService
     {
         /// <summary>
         /// Initiates a session which creates the subscription for the given <paramref name="shopperReference"/>.
@@ -31,14 +30,14 @@ namespace adyen_dotnet_subscription_example.Clients
         Task<PaymentResponse> MakePaymentAsync(string shopperReference, string recurringDetailReference, CancellationToken cancellationToken = default);
     }
 
-    public class CheckoutClient : ICheckoutClient
+    public class CheckoutService : ICheckoutService
     {
-        private readonly ILogger<RecurringClient> _logger;
+        private readonly ILogger<RecurringService> _logger;
         private readonly IPaymentsService _paymentsService;
         private readonly IUrlService _urlService;
         private readonly string _merchantAccount;
 
-        public CheckoutClient(ILogger<RecurringClient> logger, IPaymentsService paymentsService, IUrlService urlService, IOptions<AdyenOptions> options)
+        public CheckoutService(ILogger<RecurringService> logger, IPaymentsService paymentsService, IUrlService urlService, IOptions<AdyenOptions> options)
         {
             _logger = logger;
             _paymentsService = paymentsService;
@@ -54,7 +53,7 @@ namespace adyen_dotnet_subscription_example.Clients
             {
                 MerchantAccount = _merchantAccount, // Required.
                 Reference = orderRef.ToString(),    // Required.
-                
+
                 Amount = new Amount("EUR", 0),
                 Channel = CreateCheckoutSessionRequest.ChannelEnum.Web,
                 ShopperInteraction = CreateCheckoutSessionRequest.ShopperInteractionEnum.Ecommerce,

--- a/subscription-example/Services/SubscriptionService.cs
+++ b/subscription-example/Services/SubscriptionService.cs
@@ -1,15 +1,15 @@
 ﻿using Adyen.Model.Recurring;
+using Adyen.Service;
 using adyen_dotnet_subscription_example.Options;
 using adyen_dotnet_subscription_example.Repositories;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Threading;
 using System.Threading.Tasks;
-using Adyen.Service;
 
-namespace adyen_dotnet_subscription_example.Clients
+namespace adyen_dotnet_subscription_example.Services
 {
-    public interface IRecurringClient
+    public interface ISubscriptionService
     {
         /// <summary>
         /// Disables the <paramref name="recurringDetailReference"/> (token) for the given <paramref name="shopperReference"/>.
@@ -29,14 +29,14 @@ namespace adyen_dotnet_subscription_example.Clients
         Task<RecurringDetailsResult> ListRecurringDetailAsync(string shopperReference, CancellationToken cancellationToken = default);
     }
 
-    public class RecurringClient : IRecurringClient
+    public class SubscriptionService : ISubscriptionService
     {
-        private readonly ILogger<RecurringClient> _logger;
+        private readonly ILogger<SubscriptionService> _logger;
         private readonly string _merchantAccount;
         private readonly IRecurringService _recurringService;
         private readonly ISubscriptionRepository _repository;
 
-        public RecurringClient(ILogger<RecurringClient> logger, IRecurringService recurringService, ISubscriptionRepository repository, IOptions<AdyenOptions> options)
+        public SubscriptionService(ILogger<SubscriptionService> logger, IRecurringService recurringService, ISubscriptionRepository repository, IOptions<AdyenOptions> options)
         {
             _logger = logger;
             _recurringService = recurringService;

--- a/subscription-example/Startup.cs
+++ b/subscription-example/Startup.cs
@@ -2,7 +2,6 @@ using Adyen;
 using Adyen.Model;
 using Adyen.Service.Checkout;
 using Adyen.Util;
-using adyen_dotnet_subscription_example.Clients;
 using adyen_dotnet_subscription_example.Options;
 using adyen_dotnet_subscription_example.Repositories;
 using adyen_dotnet_subscription_example.Services;
@@ -73,8 +72,8 @@ namespace adyen_dotnet_subscription_example
             services.AddSingleton<Adyen.Service.IRecurringService, Adyen.Service.RecurringService>(); // Used to be called "Recurring.cs" in Adyen .NET 9.x.x and below, see https://github.com/Adyen/adyen-dotnet-api-library/blob/9.2.1/Adyen/Service/Recurring.cs.
             services.AddSingleton<HmacValidator>();
             
-            services.AddSingleton<IRecurringClient, RecurringClient>();
-            services.AddSingleton<ICheckoutClient, CheckoutClient>();
+            services.AddSingleton<ISubscriptionService, SubscriptionService>();
+            services.AddSingleton<ICheckoutService, CheckoutService>();
             services.AddSingleton<ISubscriptionRepository, SubscriptionRepository>();
         }
 

--- a/subscription-example/adyen-dotnet-subscription-example.csproj
+++ b/subscription-example/adyen-dotnet-subscription-example.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>

--- a/subscription-example/readme.md
+++ b/subscription-example/readme.md
@@ -75,12 +75,9 @@ git clone https://github.com/adyen-examples/adyen-dotnet-online-payments.git
 This demo provides a simple webhook integration at `/api/webhooks/notifications`. For it to work, you need to provide a way for Adyen's servers to reach your running application and add a standard webhook in the Customer Area. 
 To expose this endpoint locally, we have highlighted two options in step 4 or 5. Choose one or consider alternative tunneling software.
 
-
 4. Expose your localhost with Visual Studio using dev tunnels.
      - Add `https://*.devtunnels.ms` to your allowed origins
-     - Login to Visual Studio
-     - Under `Options` → `Environment` → `Preview Features` → Check `Enable dev tunnels for Web Application`
-     - Select `adyen_dotnet_subscription_example_port_tunneling` as your launch settings profile
+     - Create your public (temporary/persistent) dev tunnel by following [this guide](https://learn.microsoft.com/en-us/aspnet/core/test/dev-tunnels?view=aspnetcore-7.0)
 
 If you use Visual Studio 17.4 or higher, the webhook URL will be the generated URL (i.e. `https://xd1r2txt-5001.euw.devtunnels.ms`).
 

--- a/subscription-example/readme.md
+++ b/subscription-example/readme.md
@@ -32,7 +32,9 @@ This demo provides a simple webhook integration at `/api/webhooks/notifications`
     - Define username and password (Basic Authentication) to [protect your endpoint](https://docs.adyen.com/development-resources/webhooks/best-practices#security) - Basic authentication only guarantees that the notification was sent by Adyen, not that it wasn't modified during transmission
     - Generate the [HMAC Key](https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures) and set the `ADYEN_HMAC_KEY` in your [Gitpod Environment Variables](https://gitpod.io/variables) with a scope of `*/*` -  This key is used to [verify](https://docs.adyen.com/development-resources/webhooks/best-practices#security) whether the HMAC signature that is included in the notification, was sent by Adyen and not modified during transmission
     - For the URL, enter `https://gitpod.io` for now, we will need to update this webhook URL in step 7
-    - Make sure the webhook is **Enabled** to send notifications
+    - Make sure that the `Recurring contract` setting is **enabled** on `Merchant` account-level - In the `Customer Area`, under `Developers` -> `Webhooks` -> `Settings` -> Enable `Recurring contract` on `Merchant`-level and hit "Save".
+    - Make sure that your webhook sends the `RECURRING_CONTRACT` event when you've created the webhook
+    - Make sure the webhook is **enabled** to send notifications
 
 
 5. In the Customer Area, go to `Developers` → `Additional Settings` → Under `Payment` enable `Recurring Details` for subscriptions.
@@ -104,7 +106,9 @@ If you use a tunneling service like ngrok, the webhook URL will be the generated
     - Generate the [HMAC Key](https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures) - This key is used to [verify](https://docs.adyen.com/development-resources/webhooks/best-practices#security) whether the HMAC signature that is included in the notification, was sent by Adyen and not modified during transmission
     - See script below that allows you to easily set your environmental variables
     - For the URL, enter `https://ngrok.io` for now - We will need to update this webhook URL in step 10
-    - Make sure the webhook is **Enabled** to send notifications
+    - Make sure that the `Recurring contract` setting is **enabled** on `Merchant` account-level - In the `Customer Area`, under `Developers` -> `Webhooks` -> `Settings` -> Enable `Recurring contract` on `Merchant`-level and hit "Save".
+    - Make sure that your webhook sends the `RECURRING_CONTRACT` event when you've created the webhook
+    - Make sure the webhook is **enabled** to send notifications
 
     
 7. Set the following environment variables in your terminal environment: `ADYEN_API_KEY`, `ADYEN_CLIENT_KEY`, `ADYEN_MERCHANT_ACCOUNT` and `ADYEN_HMAC_KEY`. Note that some IDEs will have to be restarted for environmental variables to be injected properly.
@@ -147,11 +151,15 @@ dotnet run --project subscription-example
 ## Usage
 To try out this application with test card numbers, visit [Test card numbers](https://docs.adyen.com/development-resources/test-cards/test-card-numbers). We recommend saving multiple test cards in your browser so you can test your integration faster in the future.
 
-1. Visit the main page 'Shopper View' to test the application, enter one or multiple card details. Once the payment is authorized, you will receive a webhook notification with the recurringDetailReference. Enter multiple cards to receive multiple different recurringDetailReferences.
+1. Visit the main page 'Shopper View' to test the application, enter one or multiple card details. 
 
-2. Visit 'Admin Panel' to find the saved recurringDetailReferences and choose to make a payment request or disable the recurringDetailReference.
+2. Once the payment is authorized, you will receive a (delayed) webhook notification with the event code `RECURRING_CONTRACT` and the recurringDetailReference. 
 
-3. Visit the Customer Area `Developers` → `API logs` to view your logs.
+3. Enter multiple cards to receive multiple different recurringDetailReferences.
+
+4. Visit 'Admin Panel' to find the saved recurringDetailReferences and choose to make a payment request or disable the recurringDetailReference.
+
+5. Visit the Customer Area `Developers` → `API logs` to view your logs.
 
 > **Note** We currently store these values in a local memory cache, if you restart/stop the application these values are lost. However, the tokens will still be persisted on the Adyen Platform.
 > You can view the stored payment details by going to a recent payment of the shopper in the Customer Area: `Transactions` → `Payments` → `Shopper Details` → `Recurring: View stored payment details`.


### PR DESCRIPTION
* Updated webhook logic to support "RECURRING_CONTRACT" eventCode

* Updated readme to support "RECURRING_CONTRACT" eventCode 

* Removed several launchprofiles, devTunnels are now enabled through the **Visual Studio 17.6+wizard** 
_I've removed the separate profiles foreach of our samples, as it's confusing in other editors._ Example:
In Visual Studio Code, you will no longer be confused how to start the application when you see the different launch profiles, e.g. `subscription_example` vs `subscription_example_port_tunneling`.

* Added logging when exception occurs when disabling a `recurringDetailReference` or making a payment with the `recurringDetailReference`