### PR TITLE
Fix Install-script .NET 6.0 for gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,7 +13,7 @@ tasks:
       echo "Installing dotnet ..."
       wget "https://dot.net/v1/dotnet-install.sh"
       chmod +x dotnet-install.sh
-      ./dotnet-install.sh --install-dir /workspace/dotnet
+      ./dotnet-install.sh --channel 6.0 --install-dir /workspace/dotnet
       rm dotnet-install.sh
       sudo ln -s /workspace/dotnet/dotnet /usr/bin/dotnet
       echo "Installing dotnet done."


### PR DESCRIPTION
the installl-script for dotnet takes the latest LTS version (per default). With the recent release of .NET 8.0, this is now the new Long-Term Support version for dotnet moving forward. Our solutions use .NET 6.0 for now, so let's fix the install script in gitpod.yml.

Let's upgrade all our examples to .NET 8.0 later