### PR TITLE
Webhook processing: 202 response with empty body02

### DIFF
--- a/authorisation-adjustment-example/Controllers/WebhookController.cs
+++ b/authorisation-adjustment-example/Controllers/WebhookController.cs
@@ -83,7 +83,8 @@ namespace adyen_dotnet_authorisation_adjustment_example.Controllers
                 // Documentation: https://docs.adyen.com/online-payments/refund#refunded-reversed
                 await ProcessRefundedReversedNotificationAsync(container.NotificationItem);
 
-                return Ok("[accepted]");
+                // Return a 202 status with an empty response body
+                return Accepted();
             }
             catch (Exception e)
             {

--- a/checkout-example-advanced/Controllers/WebhookController.cs
+++ b/checkout-example-advanced/Controllers/WebhookController.cs
@@ -51,7 +51,8 @@ namespace adyen_dotnet_checkout_example_advanced.Controllers
                 // Process notification asynchronously.
                 await ProcessNotificationAsync(container.NotificationItem);
 
-                return Ok("[accepted]");
+                // Return a 202 status with an empty response body
+                return Accepted();
             }
             catch (Exception e)
             {

--- a/checkout-example/Controllers/WebhookController.cs
+++ b/checkout-example/Controllers/WebhookController.cs
@@ -52,7 +52,8 @@ namespace adyen_dotnet_checkout_example.Controllers
                 // Process notification asynchronously.
                 await ProcessNotificationAsync(container.NotificationItem);
 
-                return Ok("[accepted]");
+                // Return a 202 status with an empty response body
+                return StatusCode(202);
             }
             catch (Exception e)
             {

--- a/checkout-example/Controllers/WebhookController.cs
+++ b/checkout-example/Controllers/WebhookController.cs
@@ -53,7 +53,7 @@ namespace adyen_dotnet_checkout_example.Controllers
                 await ProcessNotificationAsync(container.NotificationItem);
 
                 // Return a 202 status with an empty response body
-                return StatusCode(202);
+                return Accepted();
             }
             catch (Exception e)
             {

--- a/giftcard-example/Controllers/WebhookController.cs
+++ b/giftcard-example/Controllers/WebhookController.cs
@@ -55,7 +55,8 @@ namespace adyen_dotnet_giftcard_example.Controllers
 
                 await ProcessOrderClosedNotificationAsync(container.NotificationItem);
 
-                return Ok("[accepted]");
+                // Return a 202 status with an empty response body
+                return Accepted();
             }
             catch (Exception e)
             {

--- a/giving-example/Controllers/WebhookController.cs
+++ b/giving-example/Controllers/WebhookController.cs
@@ -52,7 +52,8 @@ namespace adyen_dotnet_giving_example.Controllers
                 // Process notification asynchronously.
                 await ProcessNotificationAsync(container.NotificationItem);
 
-                return Ok("[accepted]");
+                // Return a 202 status with an empty response body
+                return Accepted();
             }
             catch (Exception e)
             {

--- a/in-person-payments-example/Controllers/WebhookController.cs
+++ b/in-person-payments-example/Controllers/WebhookController.cs
@@ -70,7 +70,8 @@ namespace adyen_dotnet_in_person_payments_example.Controllers
                 // Documentation: https://docs.adyen.com/online-payments/refund#refunded-reversed
                 await ProcessRefundedReversedNotificationAsync(container.NotificationItem);
 
-                return Ok("[accepted]");
+                // Return a 202 status with an empty response body
+                return Accepted();
             }
             catch (Exception e)
             {

--- a/in-person-payments-loyalty-example/Controllers/WebhookController.cs
+++ b/in-person-payments-loyalty-example/Controllers/WebhookController.cs
@@ -53,7 +53,8 @@ namespace adyen_dotnet_in_person_payments_loyalty_example.Controllers
                 // Documentation: https://docs.adyen.com/point-of-sale/design-your-integration/notifications/standard-notifications/#example-standard-webhook
                 await ProcessAuthorisationNotificationAsync(container.NotificationItem);
                 
-                return Ok("[accepted]");
+                // Return a 202 status with an empty response body
+                return Accepted();
             }
             catch (Exception e)
             {

--- a/paybylink-example/Controllers/WebhookController.cs
+++ b/paybylink-example/Controllers/WebhookController.cs
@@ -55,7 +55,8 @@ namespace adyen_dotnet_paybylink_example.Controllers
                 // Process notifications asynchronously.
                 await ProcessAuthorisationNotificationAsync(container.NotificationItem);
 
-                return Ok("[accepted]");
+                // Return a 202 status with an empty response body
+                return Accepted();
             }
             catch (Exception e)
             {

--- a/subscription-example/Controllers/WebhookController.cs
+++ b/subscription-example/Controllers/WebhookController.cs
@@ -56,7 +56,8 @@ namespace adyen_dotnet_subscription_example.Controllers
 
                 await ProcessRecurringContractNotificationAsync(container.NotificationItem);
 
-                return Ok("[accepted]");
+                // Return a 202 status with an empty response body
+                return Accepted();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
The latest approach to accepting webhooks requires sending the response code `202` and an empty response body.

This PR updates all webhook handlers to implement the new approach.
