### PR TITLE
fix: #143

### DIFF
--- a/giving-example/Models/Requests/DonationAmountRequest.cs
+++ b/giving-example/Models/Requests/DonationAmountRequest.cs
@@ -2,7 +2,10 @@
 {
     public class DonationAmountRequest
     {
-        public long Value { get; init; } // Amount.
-        public string Currency { get; init; }
+        public long Value { get; init; } // Amount in minor units.
+        public string Currency { get; init; } // e.g., "EUR"
+        
+        // New field to accept the payment method chosen by the user
+        public PaymentMethodDetails PaymentMethod { get; set; } 
     }
 }


### PR DESCRIPTION
The DonationAmountRequest model now has a PaymentMethod property to receive various payment methods (like cards or PayPal) dynamically.
In the controller, PaymentMethod is no longer hardcoded, and it gets passed dynamically based on the user's selection.
The client-side or API now has the ability to specify the payment method, which can be a card, PayPal, or another method supported by Adyen.