### PR TITLE
Upgrade to iDEAL 2.0

### DIFF
--- a/checkout-example-advanced/Views/Shared/_Layout.cshtml
+++ b/checkout-example-advanced/Views/Shared/_Layout.cshtml
@@ -9,13 +9,13 @@
     <link rel="stylesheet" href="~/css/site.css" />
     
     <link rel="stylesheet"
-          href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.53.2/adyen.css"
-          integrity="sha384-9EdBqZRrjozkt+Be5ycjHBTi+4DYrafpC1KyPnNyTBfjBIZ5+oMp8BbgvPLGgsE0"
-          crossorigin="anonymous">
-    
-    <script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.53.2/adyen.js"
-     integrity="sha384-ng3HLoZIlQ3BLgyGyGNiwWSx6LEPIlmxVuGRw72skZFt9mL8OweRjp7vcPzSqxTj"
-     crossorigin="anonymous"></script>
+        href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.css"
+        integrity="sha384-gpOE6R0K50VgXe6u/pyjzkKl4Kr8hXu93KUCTmC4LqbO9mpoGUYsrmeVLcp2eejn"
+        crossorigin="anonymous">
+
+    <script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.js"
+          integrity="sha384-U9GX6Oa3W024049K86PYG36/jHjkvUqsRd8Y9cF1CmB92sm4tnjxDXF/tkdcsk6k"
+          crossorigin="anonymous"></script>
     
     <title>@ViewData["Title"] - Checkout Demo Advanced</title>
 </head>

--- a/checkout-example/Views/Shared/_Layout.cshtml
+++ b/checkout-example/Views/Shared/_Layout.cshtml
@@ -9,13 +9,13 @@
     <link rel="stylesheet" href="~/css/site.css" />
 
     <link rel="stylesheet"
-          href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.40.0/adyen.css"
-          integrity="sha384-BRZCzbS8n6hZVj8BESE6thGk0zSkUZfUWxL/vhocKu12k3NZ7xpNsIK39O2aWuni"
-          crossorigin="anonymous" />
+        href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.css"
+        integrity="sha384-gpOE6R0K50VgXe6u/pyjzkKl4Kr8hXu93KUCTmC4LqbO9mpoGUYsrmeVLcp2eejn"
+        crossorigin="anonymous">
 
-    <script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.40.0/adyen.js"
-            integrity="sha384-ds1t0hgFCe636DXFRL6ciadL2Wb4Yihh27R4JO7d9CF7sFY3NJE4aPCK0EpzaYXD"
-            crossorigin="anonymous"></script>
+    <script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.js"
+          integrity="sha384-U9GX6Oa3W024049K86PYG36/jHjkvUqsRd8Y9cF1CmB92sm4tnjxDXF/tkdcsk6k"
+          crossorigin="anonymous"></script>
 
     <title>@ViewData["Title"] - Checkout Demo</title>
 </head>


### PR DESCRIPTION
Support iDEAL 2.0.

Changes required: update to `Drop-in v5.68.0`

### Note 

- on **TEST** the iDEAL payment method in the Customer Area must be updated to use the `AdyenIdeal` acquirer
- on **LIVE** no changes are required in the Customer Area