### PR TITLE
Upgrade to v35.0.0 Adyen .NET library

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build checkout-example-v6 image
         run: docker build -t checkout-example-v6-image:latest checkout-example
       - name: Start checkout-example-v6 container
-        run: docker run --rm -d --name checkout-example-v6-image -p 8080:80 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} checkout-example-v6-image:latest
+        run: docker run --rm -d --name checkout-example-v6-image -p 8080:8080 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} checkout-example-v6-image:latest
       - name: Wait for application, show docker logs if it fails
         run: curl --retry 30 --retry-delay 2 --retry-all-errors --fail http://localhost:8080 || docker logs checkout-example-v6-image
       - name: Run testing suite against checkout-example-v6-image
@@ -42,7 +42,7 @@ jobs:
       - name: Build checkout-example-advanced-v6 image
         run: docker build -t checkout-example-advanced-v6-image:latest checkout-example-advanced
       - name: Start checkout-example-advanced-v6 container
-        run: docker run --rm -d --name checkout-example-advanced-v6-image -p 8080:80 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} checkout-example-advanced-v6-image:latest
+        run: docker run --rm -d --name checkout-example-advanced-v6-image -p 8080:8080 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} checkout-example-advanced-v6-image:latest
       - name: Run testing suite against checkout-example-advanced-v6-image
         run: docker run --rm --name adyen-testing-suite -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} -e PLAYWRIGHT_FOLDERNAME=advanced-checkout/v6 --network host ghcr.io/adyen-examples/adyen-testing-suite:main
 
@@ -54,7 +54,7 @@ jobs:
       - name: Build subscription-example image
         run: docker build -t subscription-example-image:latest subscription-example
       - name: Start subscription-example container
-        run: docker run --rm -d --name subscription-example-image -p 8080:80 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} subscription-example-image:latest
+        run: docker run --rm -d --name subscription-example-image -p 8080:8080 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} subscription-example-image:latest
       - name: Run testing suite against subscription-example-image
         run: docker run --rm --name adyen-testing-suite -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} -e PLAYWRIGHT_FOLDERNAME=subscription --network host ghcr.io/adyen-examples/adyen-testing-suite:main
   
@@ -66,7 +66,7 @@ jobs:
       - name: Build giftcard-example image
         run: docker build -t giftcard-example-image:latest giftcard-example
       - name: Start giftcard-example container
-        run: docker run --rm -d --name giftcard-example-image -p 8080:80 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} giftcard-example-image:latest
+        run: docker run --rm -d --name giftcard-example-image -p 8080:8080 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} giftcard-example-image:latest
       - name: Run testing suite against giftcard-example-image
         run: docker run --rm --name adyen-testing-suite -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} -e PLAYWRIGHT_FOLDERNAME=giftcard --network host ghcr.io/adyen-examples/adyen-testing-suite:main
 
@@ -78,7 +78,7 @@ jobs:
       - name: Build paybylink-example image
         run: docker build -t paybylink-example-image:latest paybylink-example
       - name: Start paybylink-example container
-        run: docker run --rm -d --name paybylink-example-image -p 8080:80 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} paybylink-example-image:latest
+        run: docker run --rm -d --name paybylink-example-image -p 8080:8080 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} paybylink-example-image:latest
       - name: Run testing suite against paybylink-example-image
         run: docker run --rm --name adyen-testing-suite -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} -e PLAYWRIGHT_FOLDERNAME=paybylink --network host ghcr.io/adyen-examples/adyen-testing-suite:main
 
@@ -90,7 +90,7 @@ jobs:
       - name: Build authorisation-adjustment-example image
         run: docker build -t authorisation-adjustment-example-image:latest authorisation-adjustment-example
       - name: Start authorisation-adjustment-example container
-        run: docker run --rm -d --name authorisation-adjustment-example-image -p 8080:80 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} authorisation-adjustment-example-image:latest
+        run: docker run --rm -d --name authorisation-adjustment-example-image -p 8080:8080 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} authorisation-adjustment-example-image:latest
       - name: Run testing suite against authorisation-adjustment-example-image
         run: docker run --rm --name adyen-testing-suite -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} -e PLAYWRIGHT_FOLDERNAME=authorisation-adjustment --network host ghcr.io/adyen-examples/adyen-testing-suite:main
 
@@ -102,7 +102,7 @@ jobs:
       - name: Build giving-example image
         run: docker build -t giving-example-image:latest giving-example
       - name: Start giving-example container
-        run: docker run --rm -d --name giving-example-image -p 8080:80 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} giving-example-image:latest
+        run: docker run --rm -d --name giving-example-image -p 8080:8080 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} giving-example-image:latest
       - name: Run testing suite against giving-example-image
         run: docker run --rm --name adyen-testing-suite -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} -e PLAYWRIGHT_FOLDERNAME=giving --network host ghcr.io/adyen-examples/adyen-testing-suite:main
 
@@ -114,7 +114,7 @@ jobs:
       - name: Build in-person-payments-example image
         run: docker build -t in-person-payments-example-image:latest in-person-payments-example
       - name: Start in-person-payments-example container, set ADYEN_TERMINAL_API_CLOUD_ENDPOINT to default docker bridge and port 3000
-        run: docker run --rm -d --name in-person-payments-example-image -p 8080:80 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} -e ADYEN_TERMINAL_API_CLOUD_ENDPOINT=http://172.17.0.1:3000 -e ADYEN_POS_POI_ID=V400m-123456789 in-person-payments-example-image:latest
+        run: docker run --rm -d --name in-person-payments-example-image -p 8080:8080 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} -e ADYEN_TERMINAL_API_CLOUD_ENDPOINT=http://172.17.0.1:3000 -e ADYEN_POS_POI_ID=V400m-123456789 in-person-payments-example-image:latest
       - name: Start the Adyen Mock Terminal API Application on port 3000
         run: docker run --rm -d --name adyen-mock-terminal-api -p 3000:3000 -e PORT=3000 ghcr.io/adyen-examples/adyen-mock-terminal-api:main
       - name: Run testing suite against in-person-payments-example-image

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,8 @@ jobs:
         run: docker build -t checkout-example-v6-image:latest checkout-example
       - name: Start checkout-example-v6 container
         run: docker run --rm -d --name checkout-example-v6-image -p 8080:80 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} checkout-example-v6-image:latest
+      - name: Wait for application, show docker logs if it fails
+        run: curl --retry 30 --retry-delay 2 --retry-all-errors --fail http://localhost:8080 || docker logs checkout-example-v6-image
       - name: Run testing suite against checkout-example-v6-image
         run: docker run --rm --name adyen-testing-suite -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} -e PLAYWRIGHT_FOLDERNAME=checkout/v6 --network host ghcr.io/adyen-examples/adyen-testing-suite:main
 

--- a/checkout-example-advanced/Controllers/ApiController.cs
+++ b/checkout-example-advanced/Controllers/ApiController.cs
@@ -57,13 +57,10 @@ namespace adyen_dotnet_checkout_example_advanced.Controllers
         [HttpPost("api/payments")]
         public async Task<ActionResult<PaymentResponse>> Payments([FromBody] PaymentsDto paymentsDto, CancellationToken cancellationToken = default)
         {
-            // Map your DTOs here
+            // Map your DTOs.
             RiskData riskData = RiskDataDto.MapToRiskData(paymentsDto.RiskData);
             BrowserInfo browserInfo = BrowserInfoDto.MapToBrowserInfo(paymentsDto.BrowserInfo);
             CheckoutPaymentMethod paymentMethod = paymentsDto.PaymentMethod;
-            
-            string origin = paymentsDto.Origin; // Unused
-            bool clientStateDataIndicator = paymentsDto.ClientStateDataIndicator; // Unused
             
             // Create the Payment Request to Adyen.
             var orderRef = Guid.NewGuid();
@@ -72,7 +69,7 @@ namespace adyen_dotnet_checkout_example_advanced.Controllers
                 MerchantAccount = _merchantAccount, // Required.
                 Reference = orderRef.ToString(), // Required.
                 Channel = PaymentRequest.ChannelEnum.Web,
-                Amount = new Amount("EUR", 10000), // Value is 100€ in minor units.
+                Amount = new Amount() { Currency = "EUR", Value = 10000 }, // Value is 100€ in minor units.
                 
                 // Required for 3DS2 redirect flow.
                 ReturnUrl = $"{_urlService.GetHostUrl()}/api/handleShopperRedirect?orderRef={orderRef}",
@@ -82,8 +79,8 @@ namespace adyen_dotnet_checkout_example_advanced.Controllers
                 CountryCode = "NL", 
                 LineItems = new List<LineItem>()
                 {
-                    new LineItem(quantity: 1, amountIncludingTax: 5000, description: "Sunglasses"),
-                    new LineItem(quantity: 1, amountIncludingTax: 5000, description: "Headphones")
+                    new LineItem() { Quantity = 1, AmountIncludingTax = 5000, Description = "Sunglasses"},
+                    new LineItem() { Quantity = 1, AmountIncludingTax = 5000, Description = "Headphones"}
                 },
                 
                 // We strongly recommend that you the billingAddress in your request. 

--- a/checkout-example-advanced/Dockerfile
+++ b/checkout-example-advanced/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:680 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["adyen-dotnet-checkout-example-advanced.csproj", "."]
 RUN dotnet restore "./adyen-dotnet-checkout-example-advanced.csproj"

--- a/checkout-example-advanced/Dockerfile
+++ b/checkout-example-advanced/Dockerfile
@@ -1,7 +1,7 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:680 AS build
 WORKDIR /src
 COPY ["adyen-dotnet-checkout-example-advanced.csproj", "."]
 RUN dotnet restore "./adyen-dotnet-checkout-example-advanced.csproj"

--- a/checkout-example-advanced/Startup.cs
+++ b/checkout-example-advanced/Startup.cs
@@ -1,4 +1,3 @@
-using adyen_dotnet_checkout_example_advanced.Options;
 using adyen_dotnet_checkout_example_advanced.Services;
 using Adyen.Checkout.Services;
 using Adyen.Util;
@@ -29,9 +28,6 @@ namespace adyen_dotnet_checkout_example_advanced
             // Register controllers.
             services.AddControllersWithViews();
             services.AddControllers();
-            
-            // Register the JsonConverters to allow deserialization in ApiController (/api/payments) -> PaymentsDto
-            services.AddSingleton<IConfigureOptions<JsonOptions>, CheckoutJsonOptions>();
             
             services.AddHttpContextAccessor()
                 .AddTransient<IUrlService, UrlService>();

--- a/checkout-example-advanced/adyen-dotnet-checkout-example-advanced.csproj
+++ b/checkout-example-advanced/adyen-dotnet-checkout-example-advanced.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adyen" Version="34.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.30" />
+    <PackageReference Include="Adyen" Version="35.0.0-beta" />
   </ItemGroup>
 </Project>

--- a/checkout-example-advanced/adyen-dotnet-checkout-example-advanced.csproj
+++ b/checkout-example-advanced/adyen-dotnet-checkout-example-advanced.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adyen" Version="35.0.0-beta" />
+    <PackageReference Include="Adyen" Version="35.0.0" />
   </ItemGroup>
 </Project>

--- a/checkout-example/Controllers/ApiController.cs
+++ b/checkout-example/Controllers/ApiController.cs
@@ -36,7 +36,7 @@ namespace adyen_dotnet_checkout_example.Controllers
                 MerchantAccount = _merchantAccount, // Required.
                 Reference = orderRef.ToString(), // Required.
                 Channel = CreateCheckoutSessionRequest.ChannelEnum.Web,
-                Amount = new Amount("EUR", 10000), // Value is 100€ in minor units.
+                Amount = new Amount() { Currency = "EUR", Value = 10000 }, // Value is 100€ in minor units.
                 
                 // Required for 3DS2 redirect flow.
                 ReturnUrl = $"{_urlService.GetHostUrl()}/redirect?orderRef={orderRef}",
@@ -46,8 +46,8 @@ namespace adyen_dotnet_checkout_example.Controllers
                 CountryCode = "NL",
                 LineItems = new List<LineItem>()
                 {
-                    new LineItem(quantity: 1, amountIncludingTax: 5000, description: "Sunglasses"),
-                    new LineItem(quantity: 1, amountIncludingTax: 5000, description: "Headphones")
+                    new LineItem() { Quantity = 1, AmountIncludingTax = 5000, Description = "Sunglasses" },
+                    new LineItem() { Quantity = 1, AmountIncludingTax = 5000, Description = "Headphones" }
                 }
             };
 

--- a/checkout-example/Dockerfile
+++ b/checkout-example/Dockerfile
@@ -1,7 +1,7 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["adyen-dotnet-checkout-example.csproj", "."]
 RUN dotnet restore "./adyen-dotnet-checkout-example.csproj"

--- a/checkout-example/adyen-dotnet-checkout-example.csproj
+++ b/checkout-example/adyen-dotnet-checkout-example.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adyen" Version="34.0.1" />
+    <PackageReference Include="Adyen" Version="35.0.0-beta" />
   </ItemGroup>
 </Project>

--- a/checkout-example/adyen-dotnet-checkout-example.csproj
+++ b/checkout-example/adyen-dotnet-checkout-example.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adyen" Version="35.0.0-beta" />
+    <PackageReference Include="Adyen" Version="35.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Upgraded checkout-example use-cases to use the V35.0.0 of the Adyen .NET library: https://github.com/Adyen/adyen-dotnet-api-library/releases/tag/v35.0.0-beta

* checkout-example
* checkout-example-advanced

Click here for the [upgrade/migration guide (wiki)](https://github.com/Adyen/adyen-dotnet-api-library/wiki/Adyen-.NET-API-Library-v35%E2%80%90Beta-Release-Notes)


**Next steps *before merge*:**
* [x] Ensure that V35.0.0 is no longer in beta and updated the dependency to use the official release.